### PR TITLE
feat(demo): remove daily value scaling

### DIFF
--- a/demo/src/components/RuntimeTab.tsx
+++ b/demo/src/components/RuntimeTab.tsx
@@ -154,7 +154,7 @@ const RuntimeTab: React.FC<RuntimeTabProps> = ({
                     <td>
                       <strong>Battery Charge Today</strong>
                     </td>
-                    <td>{runtimeInfo.dailyTotalBatteryCharge / 10}Wh</td>
+                    <td>{runtimeInfo.dailyTotalBatteryCharge}Wh</td>
                   </tr>
                 )}
                 {runtimeInfo.dailyTotalBatteryDischarge !== undefined && (
@@ -162,7 +162,7 @@ const RuntimeTab: React.FC<RuntimeTabProps> = ({
                     <td>
                       <strong>Battery Discharge Today</strong>
                     </td>
-                    <td>{runtimeInfo.dailyTotalBatteryDischarge / 10}Wh</td>
+                    <td>{runtimeInfo.dailyTotalBatteryDischarge}Wh</td>
                   </tr>
                 )}
                 {runtimeInfo.dailyTotalLoadCharge !== undefined && (
@@ -170,7 +170,7 @@ const RuntimeTab: React.FC<RuntimeTabProps> = ({
                     <td>
                       <strong>Load Charge Today</strong>
                     </td>
-                    <td>{runtimeInfo.dailyTotalLoadCharge / 10}Wh</td>
+                    <td>{runtimeInfo.dailyTotalLoadCharge}Wh</td>
                   </tr>
                 )}
                 {runtimeInfo.dailyTotalLoadDischarge !== undefined && (
@@ -178,7 +178,7 @@ const RuntimeTab: React.FC<RuntimeTabProps> = ({
                     <td>
                       <strong>Load Discharge Today</strong>
                     </td>
-                    <td>{runtimeInfo.dailyTotalLoadDischarge / 10}Wh</td>
+                    <td>{runtimeInfo.dailyTotalLoadDischarge}Wh</td>
                   </tr>
                 )}
 


### PR DESCRIPTION
## Summary
- show raw daily runtime values in demo without dividing by 10

## Testing
- `npm test` (fails: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource')
- `npm test` (fails: TypeError: /workspace/hmjs/packages/protocol/src/HMDeviceProtocol.ts: minimatch is not a function)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9fbc3f190832e8d2874c4738aa63a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected daily energy metrics display by removing unintended scaling. Battery Charge Today, Battery Discharge Today, Load Charge Today, and Load Discharge Today now show accurate values in Wh.
  - Ensures consistency across runtime info: these fields no longer appear 10x smaller than expected.
  - UI-only change; no impact on device behavior or data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->