### PR TITLE
Add disclaimer modal for experimental Bluetooth device tool

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -793,9 +793,7 @@ const App: React.FC = () => {
   };
 
   if (!disclaimerAccepted) {
-    return (
-      <DisclaimerModal onAccept={() => setDisclaimerAccepted(true)} />
-    );
+    return <DisclaimerModal onAccept={() => setDisclaimerAccepted(true)} />;
   }
 
   return (

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -8,6 +8,7 @@ import {
   HMDeviceProtocol,
 } from "@tomquist/hmjs-protocol";
 import {
+  DisclaimerModal,
   ConnectionPanel,
   DeviceInfoTab,
   RuntimeTab,
@@ -33,6 +34,9 @@ interface FoundDevice {
 }
 
 const App: React.FC = () => {
+  // Disclaimer state
+  const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
+
   // State variables
   const [activeTab, setActiveTab] = useState<TabType>(TabType.DeviceInfo);
   const [isConnected, setIsConnected] = useState(false);
@@ -787,6 +791,12 @@ const App: React.FC = () => {
     setLogs([]);
     addLog("Logs cleared");
   };
+
+  if (!disclaimerAccepted) {
+    return (
+      <DisclaimerModal onAccept={() => setDisclaimerAccepted(true)} />
+    );
+  }
 
   return (
     <div className="container">

--- a/demo/src/components/DisclaimerModal.tsx
+++ b/demo/src/components/DisclaimerModal.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+
+interface DisclaimerModalProps {
+  onAccept: () => void;
+}
+
+const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ onAccept }) => {
+  const [accepted, setAccepted] = useState(false);
+
+  return (
+    <div className="disclaimer-overlay">
+      <div className="disclaimer-modal">
+        <div className="disclaimer-header">
+          <span className="disclaimer-icon">&#9888;</span> Warning — Use at Your
+          Own Risk
+        </div>
+        <div className="disclaimer-body">
+          <p>
+            This is an <strong>experimental tool</strong> that communicates
+            directly with your Hame battery device over Bluetooth. By using this
+            application, you acknowledge and accept the following:
+          </p>
+          <ul>
+            <li>
+              This software is{" "}
+              <strong>
+                not affiliated with, endorsed by, or supported by
+              </strong>{" "}
+              the device manufacturer.
+            </li>
+            <li>
+              Sending commands to your device may result in{" "}
+              <strong>
+                unexpected behavior, misconfiguration, or damage
+              </strong>{" "}
+              to your device.
+            </li>
+            <li>
+              This tool is provided{" "}
+              <strong>&quot;as is&quot; without any warranty</strong>, express or
+              implied. The authors assume <strong>no liability</strong> for any
+              damage, data loss, or malfunction caused by its use.
+            </li>
+            <li>
+              You are solely responsible for any actions performed through this
+              interface.
+            </li>
+          </ul>
+          <p className="disclaimer-warning">
+            Do not use this tool unless you fully understand the risks involved.
+          </p>
+        </div>
+        <div className="disclaimer-footer">
+          <label className="disclaimer-checkbox">
+            <input
+              type="checkbox"
+              checked={accepted}
+              onChange={(e) => setAccepted(e.target.checked)}
+            />
+            I have read and understand the risks, and I accept full
+            responsibility for any consequences.
+          </label>
+          <button
+            className="disclaimer-button"
+            disabled={!accepted}
+            onClick={onAccept}
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DisclaimerModal;

--- a/demo/src/components/DisclaimerModal.tsx
+++ b/demo/src/components/DisclaimerModal.tsx
@@ -23,23 +23,19 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ onAccept }) => {
           <ul>
             <li>
               This software is{" "}
-              <strong>
-                not affiliated with, endorsed by, or supported by
-              </strong>{" "}
+              <strong>not affiliated with, endorsed by, or supported by</strong>{" "}
               the device manufacturer.
             </li>
             <li>
               Sending commands to your device may result in{" "}
-              <strong>
-                unexpected behavior, misconfiguration, or damage
-              </strong>{" "}
+              <strong>unexpected behavior, misconfiguration, or damage</strong>{" "}
               to your device.
             </li>
             <li>
               This tool is provided{" "}
-              <strong>&quot;as is&quot; without any warranty</strong>, express or
-              implied. The authors assume <strong>no liability</strong> for any
-              damage, data loss, or malfunction caused by its use.
+              <strong>&quot;as is&quot; without any warranty</strong>, express
+              or implied. The authors assume <strong>no liability</strong> for
+              any damage, data loss, or malfunction caused by its use.
             </li>
             <li>
               You are solely responsible for any actions performed through this

--- a/demo/src/components/index.ts
+++ b/demo/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as DisclaimerModal } from "./DisclaimerModal.js";
 export { default as ConnectionPanel } from "./ConnectionPanel.js";
 export { default as DeviceInfoTab } from "./DeviceInfoTab.js";
 export { default as RuntimeTab } from "./RuntimeTab.js";

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -1160,3 +1160,115 @@ button#clear-logs-button:hover {
     flex: 1;
   }
 }
+
+/* Disclaimer Modal */
+.disclaimer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.disclaimer-modal {
+  background-color: #fff;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 100%;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  border-top: 4px solid #e74c3c;
+}
+
+.disclaimer-header {
+  background-color: #e74c3c;
+  color: #fff;
+  padding: 16px 24px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.disclaimer-icon {
+  font-size: 1.5rem;
+}
+
+.disclaimer-body {
+  padding: 24px;
+  line-height: 1.7;
+  color: #333;
+}
+
+.disclaimer-body p {
+  margin-bottom: 16px;
+}
+
+.disclaimer-body ul {
+  margin: 0 0 16px 20px;
+  list-style-type: disc;
+}
+
+.disclaimer-body ul li {
+  margin-bottom: 8px;
+}
+
+.disclaimer-warning {
+  color: #e74c3c;
+  font-weight: 600;
+  margin-bottom: 0;
+}
+
+.disclaimer-footer {
+  padding: 16px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.disclaimer-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.disclaimer-checkbox input[type="checkbox"] {
+  margin-top: 4px;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  cursor: pointer;
+  accent-color: #e74c3c;
+}
+
+.disclaimer-button {
+  padding: 12px 24px;
+  background-color: #e74c3c;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  align-self: flex-end;
+}
+
+.disclaimer-button:hover:not(:disabled) {
+  background-color: #c0392b;
+}
+
+.disclaimer-button:disabled {
+  background-color: #bdc3c7;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
This PR adds a disclaimer modal that users must acknowledge before accessing the application. The modal warns users about the experimental nature of the tool and the risks associated with communicating directly with Hame battery devices over Bluetooth.

## Key Changes
- **New Component**: Created `DisclaimerModal.tsx` component that displays a warning modal with:
  - Warning header with icon
  - Detailed disclaimer text explaining the experimental nature and risks
  - Checkbox requiring users to acknowledge they understand the risks
  - "Continue" button that's disabled until the checkbox is checked
  
- **App Integration**: Modified `App.tsx` to:
  - Import and render the `DisclaimerModal` component
  - Add `disclaimerAccepted` state to track user acknowledgment
  - Block access to the main application until the disclaimer is accepted
  
- **Styling**: Added comprehensive CSS styles in `styles.css` for:
  - Modal overlay with semi-transparent dark background
  - Modal container with red accent border and shadow
  - Header with warning icon and red background
  - Body content with proper typography and list styling
  - Footer with checkbox and disabled button states
  - Responsive design with padding adjustments

- **Exports**: Updated `components/index.ts` to export the new `DisclaimerModal` component

## Implementation Details
- The modal uses a fixed overlay that covers the entire viewport with a z-index of 1000
- The "Continue" button is disabled until the user checks the acknowledgment checkbox
- The disclaimer clearly states the tool is not affiliated with or endorsed by the device manufacturer
- The modal prevents access to any application features until explicitly accepted

https://claude.ai/code/session_01MyXcHsq6mVKt5joX6u6ciy