### PR TITLE
Fix disclaimer modal overflow on mobile screens

### DIFF
--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -1181,6 +1181,9 @@ button#clear-logs-button:hover {
   border-radius: 8px;
   max-width: 600px;
   width: 100%;
+  max-height: calc(100vh - 40px);
+  display: flex;
+  flex-direction: column;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
   overflow: hidden;
   border-top: 4px solid #e74c3c;
@@ -1195,6 +1198,7 @@ button#clear-logs-button:hover {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 .disclaimer-icon {
@@ -1205,6 +1209,9 @@ button#clear-logs-button:hover {
   padding: 24px;
   line-height: 1.7;
   color: #333;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .disclaimer-body p {
@@ -1231,6 +1238,7 @@ button#clear-logs-button:hover {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  flex-shrink: 0;
 }
 
 .disclaimer-checkbox {


### PR DESCRIPTION
Make the modal respect viewport height by adding max-height, making the
body section scrollable while keeping header and footer always visible.

https://claude.ai/code/session_014BjNh2oq4atjj6f8cGsvr2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined button hover styling with improved layout constraints
  * Enhanced modal design with scrollable body content while maintaining fixed header and footer positioning
  * Better handling of constrained viewport areas for improved content presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->