### PR TITLE
Add Node.js support via optional webbluetooth peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@hmjs/ble": "file:../packages/ble",
+        "@tomquist/hmjs-ble": "file:../packages/ble",
         "copy-webpack-plugin": "^13.0.0",
         "css-loader": "^7.1.2",
         "html-webpack-plugin": "^5.6.3",
@@ -790,10 +790,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@hmjs/ble": {
-      "resolved": "packages/ble",
-      "link": true
     },
     "node_modules/@hmjs/demo": {
       "resolved": "demo",
@@ -10892,6 +10888,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "webbluetooth": "*"
+      },
+      "peerDependenciesMeta": {
+        "webbluetooth": {
+          "optional": true
+        }
       }
     },
     "packages/protocol": {

--- a/packages/ble/README.md
+++ b/packages/ble/README.md
@@ -1,6 +1,6 @@
 # @tomquist/hmjs-ble
 
-BLE transport layer for HM devices using Web Bluetooth API.
+BLE transport layer for HM devices using the Web Bluetooth API. Works in browsers and in Node.js (via the optional [`webbluetooth`](https://github.com/thegecko/webbluetooth) peer dependency).
 
 ## Installation
 
@@ -59,6 +59,39 @@ console.log('Cell voltages:', cellInfo.cellVoltages);
 - **Device Configuration**: Read and write device settings
 - **Cell Monitoring**: Individual cell voltage and temperature monitoring
 - **Event-driven API**: Subscribe to device events and data updates
+
+## Node.js Usage
+
+The library auto-detects Node.js and loads the optional [`webbluetooth`](https://github.com/thegecko/webbluetooth) peer dependency (backed by BlueZ on Linux — e.g. Raspberry Pi):
+
+```bash
+npm install webbluetooth
+```
+
+Then use the manager exactly as in the browser — no extra wiring required:
+
+```typescript
+import { BLEDeviceManager } from '@tomquist/hmjs-ble';
+
+const manager = new BLEDeviceManager();
+await manager.connect();
+console.log(await manager.getDeviceInfo());
+```
+
+If you need to customise the `Bluetooth` instance (e.g. to filter devices during the Node.js scan), inject your own:
+
+```typescript
+import { Bluetooth } from 'webbluetooth';
+import { BLEDeviceManager } from '@tomquist/hmjs-ble';
+
+const bluetooth = new Bluetooth({
+  deviceFound: (device) => device.name?.startsWith('HM_') ?? false,
+});
+const manager = new BLEDeviceManager({ bluetooth });
+await manager.connect();
+```
+
+BlueZ typically needs root or `CAP_NET_ADMIN`/`CAP_NET_RAW` capabilities, so run with `sudo` or grant the Node binary capabilities.
 
 ## Browser Compatibility
 

--- a/packages/ble/package.json
+++ b/packages/ble/package.json
@@ -2,7 +2,7 @@
   "name": "@tomquist/hmjs-ble",
   "version": "0.1.0",
   "type": "module",
-  "description": "BLE transport layer for HM devices using Web Bluetooth API",
+  "description": "BLE transport layer for HM devices using the Web Bluetooth API (browser and Node.js)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -11,6 +11,14 @@
   },
   "dependencies": {
     "@tomquist/hmjs-protocol": "^0.1.0"
+  },
+  "peerDependencies": {
+    "webbluetooth": "*"
+  },
+  "peerDependenciesMeta": {
+    "webbluetooth": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/web-bluetooth": "^0.0.21",
@@ -22,7 +30,7 @@
     "url": "git+https://github.com/tomquist/hmjs.git",
     "directory": "packages/ble"
   },
-  "keywords": ["bluetooth", "ble", "battery", "hame", "typescript", "web-bluetooth"],
+  "keywords": ["bluetooth", "ble", "battery", "hame", "typescript", "web-bluetooth", "node"],
   "license": "MIT",
   "files": [
     "dist/**/*",

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -190,9 +190,25 @@ class BLEDeviceManager {
         )) as { Bluetooth: new () => Bluetooth };
         this.resolvedBluetooth = new mod.Bluetooth();
         return this.resolvedBluetooth;
-      } catch {
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const code =
+          err instanceof Error && "code" in err
+            ? (err as { code?: string }).code
+            : undefined;
+        const isModuleNotFound =
+          code === "ERR_MODULE_NOT_FOUND" ||
+          code === "MODULE_NOT_FOUND" ||
+          /Cannot find (module|package)/i.test(message);
+        if (isModuleNotFound) {
+          throw new Error(
+            "The `webbluetooth` package is not installed. Run `npm install webbluetooth`, or pass a `Bluetooth` instance via the `bluetooth` option.",
+            { cause: err },
+          );
+        }
         throw new Error(
-          "No Web Bluetooth implementation available. Install the `webbluetooth` package (`npm install webbluetooth`) or pass a `Bluetooth` instance via the `bluetooth` option.",
+          `Failed to initialize the \`webbluetooth\` Bluetooth implementation: ${message}`,
+          { cause: err },
         );
       }
     }

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -47,7 +47,12 @@ class BLEDeviceManager {
   private connecting: boolean = false;
 
   // Options with defaults
-  private options: Required<BLEManagerOptions>;
+  private options: Required<Omit<BLEManagerOptions, "bluetooth">> & {
+    bluetooth?: Bluetooth;
+  };
+
+  // Cached Web Bluetooth implementation auto-loaded in Node.js
+  private resolvedBluetooth: Bluetooth | null = null;
 
   // Protocol handler
   private protocol: HMDeviceProtocol;
@@ -87,6 +92,7 @@ class BLEDeviceManager {
       reconnectDelay: options.reconnectDelay || 2000,
       deviceNamePrefix: options.deviceNamePrefix || "HM_",
       logger: options.logger || console.log,
+      bluetooth: options.bluetooth,
     };
     this.explicitDisconnect = true;
 
@@ -163,6 +169,39 @@ class BLEDeviceManager {
   }
 
   /**
+   * Resolve a Web Bluetooth implementation. Prefers an explicit override,
+   * then `options.bluetooth`, then `navigator.bluetooth`, then auto-loads
+   * the optional `webbluetooth` peer dependency in Node.js.
+   */
+  private async resolveBluetooth(override?: Bluetooth): Promise<Bluetooth> {
+    if (override) return override;
+    if (this.options.bluetooth) return this.options.bluetooth;
+    if (typeof navigator !== "undefined" && navigator.bluetooth) {
+      return navigator.bluetooth;
+    }
+    if (this.resolvedBluetooth) return this.resolvedBluetooth;
+    const isNode =
+      typeof process !== "undefined" && process.versions?.node != null;
+    if (isNode) {
+      try {
+        const moduleName = "webbluetooth";
+        const mod = (await import(
+          /* webpackIgnore: true */ /* @vite-ignore */ moduleName
+        )) as { Bluetooth: new () => Bluetooth };
+        this.resolvedBluetooth = new mod.Bluetooth();
+        return this.resolvedBluetooth;
+      } catch {
+        throw new Error(
+          "No Web Bluetooth implementation available. Install the `webbluetooth` package (`npm install webbluetooth`) or pass a `Bluetooth` instance via the `bluetooth` option.",
+        );
+      }
+    }
+    throw new Error(
+      "Web Bluetooth API is not supported in this browser. Pass a `Bluetooth` instance via the `bluetooth` option.",
+    );
+  }
+
+  /**
    * Scan for available devices with the specified device name prefix
    * @param options Optional scan options to override defaults
    * @returns The selected device
@@ -170,22 +209,20 @@ class BLEDeviceManager {
   public async scanForDevices(
     options: Partial<BLEManagerOptions> = {},
   ): Promise<BluetoothDevice> {
-    if (!navigator.bluetooth) {
-      throw new Error("Web Bluetooth API is not supported in this browser");
-    }
-
     // Merge scan options with defaults
     const scanOptions = {
       ...this.options,
       ...options,
     };
 
+    const bluetooth = await this.resolveBluetooth(scanOptions.bluetooth);
+
     this.log("Requesting Bluetooth device...");
     this.log(`Using device name prefix: "${scanOptions.deviceNamePrefix}"`);
 
     try {
       // Request device with appropriate filters
-      const device = await navigator.bluetooth.requestDevice({
+      const device = await bluetooth.requestDevice({
         filters: [{ namePrefix: scanOptions.deviceNamePrefix }],
         optionalServices: [BLEDeviceManager.SERVICE_UUID],
       });

--- a/packages/ble/src/types.ts
+++ b/packages/ble/src/types.ts
@@ -7,6 +7,12 @@ interface BLEManagerOptions {
   reconnectDelay?: number;
   deviceNamePrefix?: string;
   logger?: (message: string, ...args: unknown[]) => void;
+  /**
+   * Web Bluetooth implementation to use. Defaults to `navigator.bluetooth`
+   * in browsers. In Node.js, the optional `webbluetooth` peer dependency is
+   * loaded automatically when installed; pass an instance here to override.
+   */
+  bluetooth?: Bluetooth;
 }
 
 export type {

--- a/packages/ble/tsconfig.json
+++ b/packages/ble/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "declaration": true,
     "composite": true,
-    "lib": ["dom"]
+    "lib": ["es2022", "dom"]
   },
   "include": ["src/**/*"],
   "references": [{ "path": "../protocol" }],


### PR DESCRIPTION
BLEDeviceManager now resolves the Web Bluetooth implementation in order: explicit `bluetooth` option, `navigator.bluetooth`, then a dynamic import of the optional `webbluetooth` package in Node.js. The dynamic import uses an indirect specifier with bundler-ignore comments so browser builds do not try to resolve the optional dep.

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BLE transport layer now supports Node.js environments in addition to browsers.

* **Documentation**
  * Added Node.js usage guide with setup instructions, auto-detection behavior, and advanced configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/hmjs/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->