### PR TITLE
Recommend Bluefy on iOS when Web Bluetooth is unavailable

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tomquist/hmjs-protocol";
 import {
   DisclaimerModal,
+  BluetoothUnsupportedModal,
   ConnectionPanel,
   DeviceInfoTab,
   RuntimeTab,
@@ -16,6 +17,7 @@ import {
   ConfigurationTab,
   AdvancedTab,
 } from "./components";
+import { isIOS, isBluetoothSupported } from "./utils/platform.js";
 
 // Tabs enum
 enum TabType {
@@ -36,6 +38,11 @@ interface FoundDevice {
 const App: React.FC = () => {
   // Disclaimer state
   const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
+
+  // Web Bluetooth unsupported state
+  const [bluetoothUnsupported, setBluetoothUnsupported] = useState(
+    () => !isBluetoothSupported(),
+  );
 
   // State variables
   const [activeTab, setActiveTab] = useState<TabType>(TabType.DeviceInfo);
@@ -239,11 +246,9 @@ const App: React.FC = () => {
     });
 
     // Check if Web Bluetooth API is supported
-    if (!navigator.bluetooth) {
+    if (!isBluetoothSupported()) {
       logFunction("Web Bluetooth API is not supported in this browser");
-      alert(
-        "Web Bluetooth is not supported in this browser. Please use Chrome, Edge, or Opera.",
-      );
+      setBluetoothUnsupported(true);
       setConnectionStatus("Bluetooth not supported in this browser");
     }
 
@@ -791,6 +796,10 @@ const App: React.FC = () => {
     setLogs([]);
     addLog("Logs cleared");
   };
+
+  if (bluetoothUnsupported) {
+    return <BluetoothUnsupportedModal isIOS={isIOS()} />;
+  }
 
   if (!disclaimerAccepted) {
     return <DisclaimerModal onAccept={() => setDisclaimerAccepted(true)} />;

--- a/demo/src/components/BluetoothUnsupportedModal.tsx
+++ b/demo/src/components/BluetoothUnsupportedModal.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+
+interface BluetoothUnsupportedModalProps {
+  isIOS: boolean;
+}
+
+const BLUEFY_APP_STORE_URL = "https://apps.apple.com/app/id1492822055";
+
+const BluetoothUnsupportedModal: React.FC<BluetoothUnsupportedModalProps> = ({
+  isIOS,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const pageUrl = typeof window !== "undefined" ? window.location.href : "";
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(pageUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="disclaimer-overlay">
+      <div className="disclaimer-modal bluetooth-unsupported-modal">
+        <div className="disclaimer-header">
+          <span className="disclaimer-icon">&#128268;</span> Web Bluetooth not
+          available
+        </div>
+        <div className="disclaimer-body">
+          {isIOS ? (
+            <>
+              <p>
+                iOS browsers (Safari, Chrome, Edge, Firefox) do{" "}
+                <strong>not support the Web Bluetooth API</strong>, so this demo
+                cannot connect to your device directly.
+              </p>
+              <p>
+                To use this tool on iPhone or iPad, please open it in{" "}
+                <strong>Bluefy – Web BLE Browser</strong>, a free third-party
+                browser that adds Web Bluetooth support on iOS:
+              </p>
+              <p>
+                <a
+                  href={BLUEFY_APP_STORE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bluefy-link"
+                >
+                  Get Bluefy on the App Store
+                </a>
+              </p>
+              <p>
+                After installing, open Bluefy and paste this page&apos;s URL
+                into its address bar:
+              </p>
+              <div className="bluetooth-url-row">
+                <code className="bluetooth-url">{pageUrl}</code>
+                <button
+                  type="button"
+                  className="disclaimer-button bluetooth-copy-button"
+                  onClick={handleCopy}
+                >
+                  {copied ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p>
+                Web Bluetooth is <strong>not supported</strong> in this browser.
+              </p>
+              <p>
+                Please open this page in <strong>Chrome</strong>,{" "}
+                <strong>Edge</strong>, or <strong>Opera</strong> on a desktop or
+                Android device.
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BluetoothUnsupportedModal;

--- a/demo/src/components/BluetoothUnsupportedModal.tsx
+++ b/demo/src/components/BluetoothUnsupportedModal.tsx
@@ -15,11 +15,46 @@ const BluetoothUnsupportedModal: React.FC<BluetoothUnsupportedModalProps> = ({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(pageUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (
+        typeof navigator !== "undefined" &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === "function"
+      ) {
+        await navigator.clipboard.writeText(pageUrl);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        return;
+      }
+
+      // Fallback for environments without the async Clipboard API
+      // (e.g. older iOS Safari, non-secure contexts).
+      if (typeof document === "undefined") {
+        return;
+      }
+      const textarea = document.createElement("textarea");
+      textarea.value = pageUrl;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.top = "0";
+      textarea.style.left = "0";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      textarea.setSelectionRange(0, pageUrl.length);
+      let ok = false;
+      try {
+        ok = document.execCommand("copy");
+      } catch {
+        ok = false;
+      }
+      document.body.removeChild(textarea);
+      if (ok) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
     } catch {
-      setCopied(false);
+      // Swallow — leave `copied` as-is so the button label doesn't lie.
     }
   };
 

--- a/demo/src/components/index.ts
+++ b/demo/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as DisclaimerModal } from "./DisclaimerModal.js";
+export { default as BluetoothUnsupportedModal } from "./BluetoothUnsupportedModal.js";
 export { default as ConnectionPanel } from "./ConnectionPanel.js";
 export { default as DeviceInfoTab } from "./DeviceInfoTab.js";
 export { default as RuntimeTab } from "./RuntimeTab.js";

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -1280,3 +1280,57 @@ button#clear-logs-button:hover {
   background-color: #bdc3c7;
   cursor: not-allowed;
 }
+
+.bluetooth-unsupported-modal {
+  border-top-color: #3498db;
+}
+
+.bluetooth-unsupported-modal .disclaimer-header {
+  background-color: #3498db;
+}
+
+.bluefy-link {
+  display: inline-block;
+  padding: 10px 16px;
+  background-color: #3498db;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.bluefy-link:hover {
+  background-color: #2980b9;
+}
+
+.bluetooth-url-row {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.bluetooth-url {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 10px 12px;
+  background-color: #f5f7fa;
+  border: 1px solid #dfe4ea;
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+  white-space: nowrap;
+  word-break: break-all;
+}
+
+.bluetooth-copy-button {
+  background-color: #3498db;
+  align-self: stretch;
+  padding: 10px 16px;
+  white-space: nowrap;
+}
+
+.bluetooth-copy-button:hover:not(:disabled) {
+  background-color: #2980b9;
+}

--- a/demo/src/utils/platform.ts
+++ b/demo/src/utils/platform.ts
@@ -1,0 +1,20 @@
+export const isIOS = (): boolean => {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const ua = navigator.userAgent || "";
+  if (/iPad|iPhone|iPod/.test(ua)) {
+    return true;
+  }
+
+  return (
+    navigator.platform === "MacIntel" &&
+    typeof navigator.maxTouchPoints === "number" &&
+    navigator.maxTouchPoints > 1
+  );
+};
+
+export const isBluetoothSupported = (): boolean => {
+  return typeof navigator !== "undefined" && !!navigator.bluetooth;
+};


### PR DESCRIPTION
iOS browsers do not ship the Web Bluetooth API, so the previous generic "use Chrome, Edge, or Opera" alert was misleading on iPhone/iPad. Detect iOS (including iPadOS reporting as MacIntel) and surface an in-app modal that points users to the Bluefy browser with the current URL and a Copy button. Non-iOS unsupported browsers still see the original guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Web Bluetooth availability detection that conditionally renders an informational modal when unsupported.
  * Platform-specific guidance provided: iOS users receive app store instructions, while others are directed to compatible browsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/hmjs/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->