### PR TITLE
Add support for multiple device types (B2500 and Tronic)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { BLEDeviceManager } from "@tomquist/hmjs-ble";
+import { BLEDeviceManager, DeviceType } from "@tomquist/hmjs-ble";
 import {
   DeviceInfo,
   RuntimeInfo,
@@ -54,6 +54,7 @@ const App: React.FC = () => {
     null,
   );
   const [allowAnyDevice, setAllowAnyDevice] = useState(false);
+  const [deviceType, setDeviceType] = useState<DeviceType>("b2500");
 
   // Track previous active tab for refresh logic
   const prevActiveTabRef = useRef<TabType>(activeTab);
@@ -266,6 +267,13 @@ const App: React.FC = () => {
       deviceManagerRef.current.setAutoReconnect(autoReconnect);
     }
   }, [autoReconnect]);
+
+  // Update device manager when deviceType changes
+  useEffect(() => {
+    if (deviceManagerRef.current) {
+      deviceManagerRef.current.setDeviceType(deviceType);
+    }
+  }, [deviceType]);
 
   // Refresh data when tab changes
   useEffect(() => {
@@ -824,10 +832,12 @@ const App: React.FC = () => {
         autoReconnect={autoReconnect}
         selectedDevice={selectedDevice}
         allowAnyDevice={allowAnyDevice}
+        deviceType={deviceType}
         onScan={scanForDevices}
         onDisconnect={disconnectFromDevice}
         onAutoReconnectChange={setAutoReconnect}
         onAllowAnyDeviceChange={setAllowAnyDevice}
+        onDeviceTypeChange={setDeviceType}
       />
 
       <div className="tabs">

--- a/demo/src/components/ConnectionPanel.tsx
+++ b/demo/src/components/ConnectionPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { DeviceType } from "@tomquist/hmjs-ble";
 
 interface FoundDevice {
   device: BluetoothDevice;
@@ -13,10 +14,12 @@ interface ConnectionPanelProps {
   autoReconnect: boolean;
   selectedDevice: FoundDevice | null;
   allowAnyDevice: boolean;
+  deviceType: DeviceType;
   onScan: () => void;
   onDisconnect: () => void;
   onAutoReconnectChange: (checked: boolean) => void;
   onAllowAnyDeviceChange: (checked: boolean) => void;
+  onDeviceTypeChange: (type: DeviceType) => void;
 }
 
 const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
@@ -26,10 +29,12 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
   autoReconnect,
   selectedDevice,
   allowAnyDevice,
+  deviceType,
   onScan,
   onDisconnect,
   onAutoReconnectChange,
   onAllowAnyDeviceChange,
+  onDeviceTypeChange,
 }) => {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
@@ -85,6 +90,23 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
               />
               Connect to any Bluetooth device
             </label>
+            <div className="device-type-selector">
+              <label htmlFor="device-type-select">Device type:</label>
+              <select
+                id="device-type-select"
+                value={deviceType}
+                disabled={isConnected}
+                onChange={(e) => onDeviceTypeChange(e.target.value as DeviceType)}
+              >
+                <option value="b2500">B2500 (default)</option>
+                <option value="tronic">Tronic / Lidl (experimental)</option>
+              </select>
+              {deviceType === "tronic" && (
+                <p className="device-type-warning">
+                  ⚠️ Experimental: Tronic support is untested and may not work correctly.
+                </p>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/demo/src/components/ConnectionPanel.tsx
+++ b/demo/src/components/ConnectionPanel.tsx
@@ -96,14 +96,17 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
                 id="device-type-select"
                 value={deviceType}
                 disabled={isConnected}
-                onChange={(e) => onDeviceTypeChange(e.target.value as DeviceType)}
+                onChange={(e) =>
+                  onDeviceTypeChange(e.target.value as DeviceType)
+                }
               >
                 <option value="b2500">B2500 (default)</option>
                 <option value="tronic">Tronic / Lidl (experimental)</option>
               </select>
               {deviceType === "tronic" && (
                 <p className="device-type-warning">
-                  ⚠️ Experimental: Tronic support is untested and may not work correctly.
+                  ⚠️ Experimental: Tronic support is untested and may not work
+                  correctly.
                 </p>
               )}
             </div>

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -713,6 +713,14 @@ class BLEDeviceManager {
   }
 
   /**
+   * Set the device type. Takes effect on the next connect().
+   * Cannot be changed while connected.
+   */
+  public setDeviceType(type: DeviceType): void {
+    this.options.deviceType = type;
+  }
+
+  /**
    * Send raw bytes to the device
    * @param bytes Raw bytes to send as Uint8Array
    * @returns Promise that resolves when command is sent

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -359,9 +359,7 @@ class BLEDeviceManager {
       );
 
       this.log(`Getting status characteristic (${uuids.status})...`);
-      this.statusCharacteristic = await service.getCharacteristic(
-        uuids.status,
-      );
+      this.statusCharacteristic = await service.getCharacteristic(uuids.status);
 
       // Setup notification handler for status characteristic
       await this.statusCharacteristic.startNotifications();

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -12,6 +12,7 @@ import {
 } from "@tomquist/hmjs-protocol";
 import {
   BLEManagerOptions,
+  DeviceType,
   EventCallback,
   NotificationHandlerMap,
 } from "./types.js";
@@ -51,6 +52,22 @@ class BLEDeviceManager {
     bluetooth?: Bluetooth;
   };
 
+  private get characteristicUUIDs(): {
+    command: string;
+    status: string;
+  } {
+    if (this.options.deviceType === "tronic") {
+      return {
+        command: BLEDeviceManager.TRONIC_COMMAND_UUID,
+        status: BLEDeviceManager.TRONIC_STATUS_UUID,
+      };
+    }
+    return {
+      command: BLEDeviceManager.B2500_COMMAND_UUID,
+      status: BLEDeviceManager.B2500_STATUS_UUID,
+    };
+  }
+
   // Cached Web Bluetooth implementation auto-loaded in Node.js
   private resolvedBluetooth: Bluetooth | null = null;
 
@@ -59,10 +76,20 @@ class BLEDeviceManager {
 
   // Service and characteristic UUIDs
   static readonly SERVICE_UUID = "0000ff00-0000-1000-8000-00805f9b34fb";
+
+  // B2500 (200-series, default)
+  static readonly B2500_COMMAND_UUID = "0000ff01-0000-1000-8000-00805f9b34fb";
+  static readonly B2500_STATUS_UUID = "0000ff02-0000-1000-8000-00805f9b34fb";
+
+  // Tronic / 100-series (experimental)
+  static readonly TRONIC_COMMAND_UUID = "0000ff03-0000-1000-8000-00805f9b34fb";
+  static readonly TRONIC_STATUS_UUID = "0000ff01-0000-1000-8000-00805f9b34fb";
+
+  // Keep legacy aliases pointing at B2500 defaults for backwards compatibility
   static readonly COMMAND_CHARACTERISTIC_UUID =
-    "0000ff01-0000-1000-8000-00805f9b34fb";
+    BLEDeviceManager.B2500_COMMAND_UUID;
   static readonly STATUS_CHARACTERISTIC_UUID =
-    "0000ff02-0000-1000-8000-00805f9b34fb";
+    BLEDeviceManager.B2500_STATUS_UUID;
 
   // Event listeners
   private eventListeners: EventMap = {
@@ -94,6 +121,7 @@ class BLEDeviceManager {
       acceptAllDevices: options.acceptAllDevices ?? false,
       logger: options.logger || console.log,
       bluetooth: options.bluetooth,
+      deviceType: options.deviceType ?? "b2500",
     };
     this.explicitDisconnect = true;
 
@@ -321,15 +349,18 @@ class BLEDeviceManager {
         BLEDeviceManager.SERVICE_UUID,
       );
 
-      // Get characteristics
-      this.log("Getting command characteristic...");
+      // Get characteristics (UUIDs depend on device type)
+      const uuids = this.characteristicUUIDs;
+      this.log(
+        `Getting command characteristic (${uuids.command}, deviceType=${connectionOptions.deviceType ?? this.options.deviceType})...`,
+      );
       this.commandCharacteristic = await service.getCharacteristic(
-        BLEDeviceManager.COMMAND_CHARACTERISTIC_UUID,
+        uuids.command,
       );
 
-      this.log("Getting status characteristic...");
+      this.log(`Getting status characteristic (${uuids.status})...`);
       this.statusCharacteristic = await service.getCharacteristic(
-        BLEDeviceManager.STATUS_CHARACTERISTIC_UUID,
+        uuids.status,
       );
 
       // Setup notification handler for status characteristic
@@ -409,13 +440,14 @@ class BLEDeviceManager {
             BLEDeviceManager.SERVICE_UUID,
           );
 
-          // Get characteristics
+          // Get characteristics (UUIDs depend on device type)
+          const uuids = this.characteristicUUIDs;
           this.commandCharacteristic = await service.getCharacteristic(
-            BLEDeviceManager.COMMAND_CHARACTERISTIC_UUID,
+            uuids.command,
           );
 
           this.statusCharacteristic = await service.getCharacteristic(
-            BLEDeviceManager.STATUS_CHARACTERISTIC_UUID,
+            uuids.status,
           );
 
           // Setup notification handler

--- a/packages/ble/src/index.ts
+++ b/packages/ble/src/index.ts
@@ -9,4 +9,4 @@
 export { BLEDeviceManager } from "./BLEDeviceManager.js";
 
 // Export BLE-specific types
-export type { BLEManagerOptions, EventCallback } from "./types.js";
+export type { BLEManagerOptions, DeviceType, EventCallback } from "./types.js";

--- a/packages/ble/src/types.ts
+++ b/packages/ble/src/types.ts
@@ -2,6 +2,14 @@ type EventCallback<T extends unknown[] = unknown[]> = (...args: T) => void;
 type NotificationHandler = (response: unknown) => void;
 type NotificationHandlerMap = Record<number, NotificationHandler>;
 
+/**
+ * "b2500"  – Marstek B2500 / 200-series firmware (default)
+ *   Command: FF01, Status/Notify: FF02
+ * "tronic" – Lidl Tronic / 100-series firmware (experimental)
+ *   Command: FF03, Status/Notify: FF01
+ */
+type DeviceType = "b2500" | "tronic";
+
 interface BLEManagerOptions {
   autoReconnect?: boolean;
   reconnectDelay?: number;
@@ -14,9 +22,15 @@ interface BLEManagerOptions {
    * loaded automatically when installed; pass an instance here to override.
    */
   bluetooth?: Bluetooth;
+  /**
+   * Target device type. Controls which BLE characteristic UUIDs are used.
+   * Defaults to "b2500". Set to "tronic" for Lidl Tronic devices (experimental).
+   */
+  deviceType?: DeviceType;
 }
 
 export type {
+  DeviceType,
   EventCallback,
   NotificationHandler,
   NotificationHandlerMap,


### PR DESCRIPTION
## Summary
This PR adds support for multiple BLE device types with different characteristic UUIDs. It introduces a `DeviceType` configuration option to allow users to select between B2500 (200-series, default) and Tronic/Lidl (100-series, experimental) devices.

## Key Changes
- **New `DeviceType` type**: Added `"b2500"` (default) and `"tronic"` (experimental) device type options
- **Device-specific UUIDs**: Separated characteristic UUIDs by device type:
  - B2500: Command (FF01), Status (FF02)
  - Tronic: Command (FF03), Status (FF01)
- **Dynamic UUID selection**: Added `characteristicUUIDs` getter that returns the appropriate UUIDs based on the configured device type
- **Configuration option**: Added `deviceType` parameter to `BLEManagerOptions` with default value of `"b2500"`
- **Runtime configuration**: Added `setDeviceType()` method to allow changing device type before connection
- **UI controls**: Added device type selector dropdown in the demo app with experimental warning for Tronic devices
- **Backwards compatibility**: Maintained legacy `COMMAND_CHARACTERISTIC_UUID` and `STATUS_CHARACTERISTIC_UUID` constants pointing to B2500 defaults
- **Export updates**: Exported `DeviceType` from the main package index

## Implementation Details
- The device type is stored in `BLEManagerOptions` and used during characteristic discovery in both the initial connection and reconnection flows
- The characteristic UUID selection is centralized in the `characteristicUUIDs` getter to avoid duplication
- Enhanced logging includes the device type and characteristic UUID for debugging purposes
- The demo app includes state management for device type selection and prevents changes while connected

https://claude.ai/code/session_018A7WdAgqnLwtgXEjsuahGp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New device type selector in advanced connection options allows choosing between B2500 (default) and Tronic/Lidl devices before establishing a connection.
  * Experimental Tronic device support includes a warning message to alert users of its beta and experimental status.
  * The device type selector is disabled while actively connected to a device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->