### PR TITLE
Support older Web Bluetooth implementations without writeValueWithoutResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Fall back to the deprecated `writeValue()` when the command characteristic
+  does not implement `writeValueWithoutResponse()`. This fixes
+  "writeValueWithoutResponse is not a function" errors on older Web Bluetooth
+  implementations such as Bluefy on iOS (#8).
 ### Security
 
 ## [0.1.0] - 2024-01-XX

--- a/packages/ble/src/BLEDeviceManager.spec.ts
+++ b/packages/ble/src/BLEDeviceManager.spec.ts
@@ -5,4 +5,54 @@ describe("BLEDeviceManager", () => {
     const manager = new BLEDeviceManager();
     expect(manager).toBeInstanceOf(BLEDeviceManager);
   });
+
+  describe("sendRawBytes", () => {
+    const connectWithCharacteristic = (
+      characteristic: Record<string, unknown>,
+    ): BLEDeviceManager => {
+      const manager = new BLEDeviceManager();
+      // Inject connection state to exercise the write path directly.
+      const internals = manager as unknown as {
+        connected: boolean;
+        commandCharacteristic: unknown;
+      };
+      internals.connected = true;
+      internals.commandCharacteristic = characteristic;
+      return manager;
+    };
+
+    it("prefers writeValueWithoutResponse when available", async () => {
+      const writeValueWithoutResponse = jest.fn().mockResolvedValue(undefined);
+      const writeValue = jest.fn().mockResolvedValue(undefined);
+      const manager = connectWithCharacteristic({
+        writeValueWithoutResponse,
+        writeValue,
+      });
+
+      const bytes = new Uint8Array([0x01, 0x02]);
+      await manager.sendRawBytes(bytes);
+
+      expect(writeValueWithoutResponse).toHaveBeenCalledWith(bytes);
+      expect(writeValue).not.toHaveBeenCalled();
+    });
+
+    it("falls back to writeValue when writeValueWithoutResponse is unavailable", async () => {
+      // Simulates older Web Bluetooth implementations such as Bluefy on iOS.
+      const writeValue = jest.fn().mockResolvedValue(undefined);
+      const manager = connectWithCharacteristic({ writeValue });
+
+      const bytes = new Uint8Array([0x01, 0x02]);
+      await manager.sendRawBytes(bytes);
+
+      expect(writeValue).toHaveBeenCalledWith(bytes);
+    });
+
+    it("throws when no write method is supported", async () => {
+      const manager = connectWithCharacteristic({});
+
+      await expect(
+        manager.sendRawBytes(new Uint8Array([0x01])),
+      ).rejects.toThrow(/does not support writing/);
+    });
+  });
 });

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -545,9 +545,7 @@ class BLEDeviceManager {
       // Deprecated, but widely supported on older implementations.
       await characteristic.writeValue(value);
     } else {
-      throw new Error(
-        "Command characteristic does not support writing values",
-      );
+      throw new Error("Command characteristic does not support writing values");
     }
   }
 

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -524,6 +524,34 @@ class BLEDeviceManager {
   }
 
   /**
+   * Write a value to the command characteristic.
+   *
+   * Prefers `writeValueWithoutResponse()`, but falls back to the older
+   * `writeValue()` method for Web Bluetooth implementations that don't
+   * expose it (e.g. Bluefy on iOS), which would otherwise throw
+   * "writeValueWithoutResponse is not a function".
+   *
+   * @param value Bytes to write
+   */
+  private async writeCommandValue(value: BufferSource): Promise<void> {
+    const characteristic = this.commandCharacteristic;
+    if (!characteristic) {
+      throw new Error("Not connected to device");
+    }
+
+    if (typeof characteristic.writeValueWithoutResponse === "function") {
+      await characteristic.writeValueWithoutResponse(value);
+    } else if (typeof characteristic.writeValue === "function") {
+      // Deprecated, but widely supported on older implementations.
+      await characteristic.writeValue(value);
+    } else {
+      throw new Error(
+        "Command characteristic does not support writing values",
+      );
+    }
+  }
+
+  /**
    * Send a command to the device and optionally wait for a response
    * @param commandType Command type
    * @param payload Optional payload data
@@ -548,11 +576,11 @@ class BLEDeviceManager {
     try {
       // Create the command message using the protocol
       const command = this.protocol.createCommandMessage(commandType, payload);
-      await this.commandCharacteristic.writeValueWithoutResponse(command);
+      await this.writeCommandValue(command);
 
       // Send twice for reliability if enabled
       if (cmdOptions.sendTwice) {
-        await this.commandCharacteristic.writeValueWithoutResponse(command);
+        await this.writeCommandValue(command);
       }
 
       this.log(`Command sent: 0x${commandType.toString(16)}`);
@@ -736,7 +764,7 @@ class BLEDeviceManager {
       );
 
       // Send the raw command
-      await this.commandCharacteristic.writeValueWithoutResponse(bytes);
+      await this.writeCommandValue(bytes);
 
       this.log(`Raw command sent successfully`);
     } catch (error) {


### PR DESCRIPTION
## Summary
This PR adds fallback support for older Web Bluetooth implementations that don't expose the `writeValueWithoutResponse()` method on BLE characteristics. The fix ensures compatibility with platforms like Bluefy on iOS while maintaining the preferred behavior on modern implementations.

## Changes
- **New `writeCommandValue()` method**: Encapsulates the write logic with intelligent fallback behavior:
  - Prefers `writeValueWithoutResponse()` when available (modern implementations)
  - Falls back to the deprecated `writeValue()` method for older implementations
  - Throws a descriptive error if neither method is supported
  
- **Updated write calls**: Replaced all direct calls to `writeValueWithoutResponse()` with the new `writeCommandValue()` method in:
  - `sendCommand()` method (including the `sendTwice` path)
  - `sendRawBytes()` method

- **Comprehensive test coverage**: Added three test cases for `sendRawBytes()`:
  - Verifies preference for `writeValueWithoutResponse()` when available
  - Verifies fallback to `writeValue()` when needed
  - Verifies appropriate error handling when no write method is supported

## Implementation Details
The solution uses runtime type checking (`typeof characteristic.writeValueWithoutResponse === "function"`) to detect method availability, avoiding static type errors while gracefully handling both old and new Web Bluetooth API versions. This approach is non-breaking and maintains backward compatibility.

https://claude.ai/code/session_01FT5C9wREDd9Ti46BHqUdas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility with older Bluetooth device implementations by adding fallback support for write operations, resolving connectivity errors on devices like Bluefy on iOS.

* **Tests**
  * Added comprehensive test coverage for Bluetooth write operation fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->