### PR TITLE
fix(ble): correct Tronic service UUID to 0x00FF

### DIFF
--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -52,17 +52,20 @@ class BLEDeviceManager {
     bluetooth?: Bluetooth;
   };
 
-  private get characteristicUUIDs(): {
+  private get deviceUUIDs(): {
+    service: string;
     command: string;
     status: string;
   } {
     if (this.options.deviceType === "tronic") {
       return {
+        service: BLEDeviceManager.TRONIC_SERVICE_UUID,
         command: BLEDeviceManager.TRONIC_COMMAND_UUID,
         status: BLEDeviceManager.TRONIC_STATUS_UUID,
       };
     }
     return {
+      service: BLEDeviceManager.SERVICE_UUID,
       command: BLEDeviceManager.B2500_COMMAND_UUID,
       status: BLEDeviceManager.B2500_STATUS_UUID,
     };
@@ -82,6 +85,8 @@ class BLEDeviceManager {
   static readonly B2500_STATUS_UUID = "0000ff02-0000-1000-8000-00805f9b34fb";
 
   // Tronic / 100-series (experimental)
+  // Service UUID is 0x00FF (000000ff-...), different from B2500's 0xFF00 (0000ff00-...)
+  static readonly TRONIC_SERVICE_UUID = "000000ff-0000-1000-8000-00805f9b34fb";
   static readonly TRONIC_COMMAND_UUID = "0000ff03-0000-1000-8000-00805f9b34fb";
   static readonly TRONIC_STATUS_UUID = "0000ff01-0000-1000-8000-00805f9b34fb";
 
@@ -272,14 +277,15 @@ class BLEDeviceManager {
     try {
       // Request device with appropriate filters. The Web Bluetooth API allows
       // either `filters` or `acceptAllDevices`, but not both at once.
+      const serviceUUID = this.deviceUUIDs.service;
       const requestOptions = scanOptions.acceptAllDevices
         ? {
             acceptAllDevices: true,
-            optionalServices: [BLEDeviceManager.SERVICE_UUID],
+            optionalServices: [serviceUUID],
           }
         : {
             filters: [{ namePrefix: scanOptions.deviceNamePrefix }],
-            optionalServices: [BLEDeviceManager.SERVICE_UUID],
+            optionalServices: [serviceUUID],
           };
       const device = await bluetooth.requestDevice(requestOptions);
 
@@ -343,17 +349,15 @@ class BLEDeviceManager {
       this.log("Connecting to GATT server...");
       const server = await this.device.gatt!.connect();
 
-      // Get primary service
-      this.log(`Getting primary service (${BLEDeviceManager.SERVICE_UUID})...`);
-      const service = await server.getPrimaryService(
-        BLEDeviceManager.SERVICE_UUID,
-      );
-
-      // Get characteristics (UUIDs depend on device type)
-      const uuids = this.characteristicUUIDs;
+      // Get primary service (UUID depends on device type)
+      const uuids = this.deviceUUIDs;
       this.log(
-        `Getting command characteristic (${uuids.command}, deviceType=${connectionOptions.deviceType ?? this.options.deviceType})...`,
+        `Getting primary service (${uuids.service}, deviceType=${this.options.deviceType})...`,
       );
+      const service = await server.getPrimaryService(uuids.service);
+
+      // Get characteristics
+      this.log(`Getting command characteristic (${uuids.command})...`);
       this.commandCharacteristic = await service.getCharacteristic(
         uuids.command,
       );
@@ -433,13 +437,10 @@ class BLEDeviceManager {
           // Connect to GATT server
           const server = await lastDevice.gatt!.connect();
 
-          // Get primary service
-          const service = await server.getPrimaryService(
-            BLEDeviceManager.SERVICE_UUID,
-          );
+          // Get primary service (UUID depends on device type)
+          const uuids = this.deviceUUIDs;
+          const service = await server.getPrimaryService(uuids.service);
 
-          // Get characteristics (UUIDs depend on device type)
-          const uuids = this.characteristicUUIDs;
           this.commandCharacteristic = await service.getCharacteristic(
             uuids.command,
           );

--- a/packages/ble/src/BLEDeviceManager.ts
+++ b/packages/ble/src/BLEDeviceManager.ts
@@ -52,12 +52,12 @@ class BLEDeviceManager {
     bluetooth?: Bluetooth;
   };
 
-  private get deviceUUIDs(): {
+  private getDeviceUUIDs(deviceType: DeviceType = this.options.deviceType): {
     service: string;
     command: string;
     status: string;
   } {
-    if (this.options.deviceType === "tronic") {
+    if (deviceType === "tronic") {
       return {
         service: BLEDeviceManager.TRONIC_SERVICE_UUID,
         command: BLEDeviceManager.TRONIC_COMMAND_UUID,
@@ -277,7 +277,7 @@ class BLEDeviceManager {
     try {
       // Request device with appropriate filters. The Web Bluetooth API allows
       // either `filters` or `acceptAllDevices`, but not both at once.
-      const serviceUUID = this.deviceUUIDs.service;
+      const serviceUUID = this.getDeviceUUIDs(scanOptions.deviceType).service;
       const requestOptions = scanOptions.acceptAllDevices
         ? {
             acceptAllDevices: true,
@@ -350,9 +350,9 @@ class BLEDeviceManager {
       const server = await this.device.gatt!.connect();
 
       // Get primary service (UUID depends on device type)
-      const uuids = this.deviceUUIDs;
+      const uuids = this.getDeviceUUIDs(connectionOptions.deviceType);
       this.log(
-        `Getting primary service (${uuids.service}, deviceType=${this.options.deviceType})...`,
+        `Getting primary service (${uuids.service}, deviceType=${connectionOptions.deviceType ?? this.options.deviceType})...`,
       );
       const service = await server.getPrimaryService(uuids.service);
 
@@ -438,7 +438,7 @@ class BLEDeviceManager {
           const server = await lastDevice.gatt!.connect();
 
           // Get primary service (UUID depends on device type)
-          const uuids = this.deviceUUIDs;
+          const uuids = this.getDeviceUUIDs(this.options.deviceType);
           const service = await server.getPrimaryService(uuids.service);
 
           this.commandCharacteristic = await service.getCharacteristic(


### PR DESCRIPTION
## Summary

- The Lidl Tronic's primary BLE service UUID is `0x00FF` (`000000ff-0000-1000-8000-00805f9b34fb`), **not** `0xFF00` like the B2500
- This one-byte difference caused a "No Services matching UUID" error because the Web Bluetooth API blocks access to any service not declared in `optionalServices` at scan time
- Also adds a `TRONIC_SERVICE_UUID` static constant and refactors the UUID selection into a `deviceUUIDs` getter (service + command + status) so all three are selected consistently based on `deviceType`

Confirmed via nRF Connect screenshot from a real Tronic device showing service `0x00FF` with characteristics FF01 (NOTIFY/READ/WRITE), FF02 (READ, "GRT3"), FF03–FF05 (WRITE).

## Test plan

- [ ] Connect to a B2500 with default settings — behaviour unchanged
- [ ] Select "Tronic / Lidl (experimental)" in Advanced Options, scan and connect — should now discover the service and characteristics successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_018A7WdAgqnLwtgXEjsuahGp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth device connection consistency across different device types during scanning, connection, and auto-reconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->