### PR TITLE
Add Marstek ecosystem overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A TypeScript library for communicating with Hame battery devices via Bluetooth Low Energy (BLE). Primary support for the B2500 model.
 
+<!-- marstek-family:start -->
+**🔋 The Marstek ecosystem.** This repo is part of a family of open-source tools for Marstek batteries (B2500, Venus, Jupiter, …):
+
+| Project | What it does |
+|---|---|
+| [hm2mqtt](https://github.com/tomquist/hm2mqtt) | Brings your battery into your smart home, turning its raw data into readable sensors and controls (e.g. in Home Assistant) |
+| [hame-relay](https://github.com/tomquist/hame-relay) | Connects the official Marstek cloud/app and your local smart home so both work together, forwarding data whichever way your battery is set up |
+| [marsrelay](https://github.com/tomquist/marsrelay) | Runs your battery completely offline, with no internet or Marstek cloud, while still sending all its data to your smart home |
+| [AstraMeter](https://github.com/tomquist/astrameter) | Tells your battery your live grid usage (read from your existing meter) so it charges and discharges to avoid buying or selling power |
+| **hmjs** (this repo) | Sets up and configures B2500 batteries over Bluetooth, right from your web browser, with no app or account needed |
+| [esphome-b2500](https://github.com/tomquist/esphome-b2500) | Continuously monitors and controls a B2500 over Bluetooth using a small ESP32 board |
+<!-- marstek-family:end -->
+
 ## Overview
 
 HMJS provides a simple interface for connecting to and monitoring Hame battery management systems through the Web Bluetooth API. The library includes device information retrieval, real-time monitoring, and configuration capabilities.


### PR DESCRIPTION
## Summary
Added a new section to the README that documents the broader Marstek ecosystem of open-source tools and how this project (hmjs) fits within it.

## Changes
- Added a "Marstek ecosystem" section with a table listing related projects:
  - hm2mqtt: Smart home integration for Marstek batteries
  - hame-relay: Cloud and local smart home synchronization
  - marsrelay: Offline battery operation
  - AstraMeter: Grid usage awareness for charging/discharging optimization
  - hmjs (this repo): Web-based B2500 setup and configuration
  - esphome-b2500: ESP32-based Bluetooth monitoring and control
- Wrapped the section with HTML comments (`marstek-family:start` and `marstek-family:end`) to allow for automated updates across the ecosystem

## Details
This change improves discoverability and provides users with a clear understanding of how hmjs relates to other tools in the Marstek ecosystem, helping them find complementary projects that may suit their needs.

https://claude.ai/code/session_014X7oipnV3LXbrsLYoii4yq